### PR TITLE
Converted array of features into a Map for performances

### DIFF
--- a/example/src/flags.json
+++ b/example/src/flags.json
@@ -1,4 +1,4 @@
 [
-    {"name": "isAdmin", "enabled": true},
-    {"name": "isFunny", "enabled": false}
+  ["isAdmin", true],
+  ["isFunny", false]
 ]

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -6,8 +6,10 @@ import { ReactSimpleFlagsProvider } from "react-simple-flags";
 import App from "./App";
 import flags from "./flags.json";
 
+type JSONFlags = [string, boolean][];
+
 ReactDOM.render(
-  <ReactSimpleFlagsProvider initialFlags={flags}>
+  <ReactSimpleFlagsProvider initialFlags={new Map(flags as JSONFlags)}>
     <App />
   </ReactSimpleFlagsProvider>,
   document.getElementById("root")

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -1,9 +1,6 @@
 import React from 'react'
-export interface ReactSimpleFlagProps {
-  name: string;
-  enabled: boolean;
-}
-export type ReactSimpleFlagsProps = ReactSimpleFlagProps[]
+
+export type ReactSimpleFlagsProps = Map<string, boolean>
 
 export const ReactSimpleFlagsContext =
-  React.createContext<ReactSimpleFlagsProps>([])
+  React.createContext<ReactSimpleFlagsProps>(new Map<string, boolean>())

--- a/src/hook.tsx
+++ b/src/hook.tsx
@@ -5,9 +5,5 @@ export const useReactSimpleFlags = (flag: string): boolean => {
   const context = useContext(ReactSimpleFlagsContext)
   if (!context) return false
 
-  const match = context?.find((f) => f.name === flag)
-
-  if (!match) return false
-
-  return Boolean(match.enabled)
+  return Boolean(context.get(flag))
 }


### PR DESCRIPTION
Fixes https://github.com/emileaublet/react-simple-flags/issues/1
This is an example of implementation, in this example I changed the JSON definition but it doesn't have to be like this, I just though this storage format was smaller to download and still readable. In case the JSON source is not flexible in terms of structure it could also be remapped with a simple utility only once just after loading the JSON from a hypothetical server

ie: 


```ts
function mapOldStructureToSimplerOne(
  features: { name: string; enabled: boolean }[],
): [string, boolean][] {
  return features.map(({ name, enabled }) => [name, enabled]);
}
```